### PR TITLE
Source.GetState

### DIFF
--- a/al/source.go
+++ b/al/source.go
@@ -364,6 +364,12 @@ func (source Source) GetBuffer() (Buffer, error) {
 	return buf, GetError()
 }
 
+func (source Source) GetState() (SourceState, error) {
+	var val C.ALint
+	C.alGetSourcei(source.source, C.AL_SOURCE_STATE, &val)
+	return SourceState(val), GetError()
+}
+
 func (source Source) GetSourceState() (SourceState, error) {
 	var val C.ALint
 	C.alGetSourcei(source.source, C.AL_BUFFER, &val)


### PR DESCRIPTION
First of all, thanks for bindings. Example and wav-decoder were very helpful. I had only minor issues with `GetSourceState`. Here is minimal code to reproduce:

	device, _ := alc.OpenDefaultDevice()
	context, _ := alc.CreateDefaultContext(device)
	context.MakeCurrent()
	context.Process()
	source, _ := al.GenSource()
	rawDat, _ := wav.LoadWavFile("gameover.wav")
	dat, _ := wav.ToALData(rawDat)
	buf, _ := al.GenBuffer()
	buf.BufferData(dat)
	source.SetBuffer(buf)

	state, _ := source.GetSourceState()
	fmt.Println(state, state == al.Initial) // prints 2, false

	source.Play()

	state, _ = source.GetSourceState()
	fmt.Println(state, state == al.Playing) // prints 2, false

	time.Sleep(1500 * time.Millisecond)

	state, _ = source.GetSourceState()
	fmt.Println(state, state == al.Stopped) // prints 2, false

So I added `GetState` function. I left old function alone because streamex example never stops playing otherwise. 